### PR TITLE
로그인 관련 기능을 수정한다.

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/MemberServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberServiceImpl.java
@@ -9,7 +9,6 @@ import jungle.HandTris.domain.exception.UserNotFoundException;
 import jungle.HandTris.domain.repo.MemberRepository;
 import jungle.HandTris.global.jwt.JWTUtil;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
-import jungle.HandTris.presentation.dto.response.MemberDetailRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -26,7 +25,7 @@ public class MemberServiceImpl implements MemberService {
     private final JWTUtil jwtUtil;
 
     @Transactional
-    public Pair<MemberDetailRes, String> signin (MemberRequest memberRequest) {
+    public Pair<Member, String> signin (MemberRequest memberRequest) {
         String username = memberRequest.username();
         String password = memberRequest.password();
 
@@ -44,7 +43,7 @@ public class MemberServiceImpl implements MemberService {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
-        return Pair.of(new MemberDetailRes(member.getUsername(), member.getNickname()), accessToken);
+        return Pair.of(member, accessToken);
     }
 
     @Transactional

--- a/src/main/java/jungle/HandTris/application/service/MemberService.java
+++ b/src/main/java/jungle/HandTris/application/service/MemberService.java
@@ -1,11 +1,11 @@
 package jungle.HandTris.application.service;
 
+import jungle.HandTris.domain.Member;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
-import jungle.HandTris.presentation.dto.response.MemberDetailRes;
 import org.springframework.data.util.Pair;
 
 public interface MemberService {
-    Pair<MemberDetailRes, String> signin(MemberRequest memberRequest);
+    Pair<Member, String> signin(MemberRequest memberRequest);
 
     void signup(MemberRequest memberRequest);
 

--- a/src/main/java/jungle/HandTris/presentation/AuthController.java
+++ b/src/main/java/jungle/HandTris/presentation/AuthController.java
@@ -3,12 +3,10 @@ package jungle.HandTris.presentation;
 import jakarta.validation.Valid;
 import jungle.HandTris.application.service.MemberService;
 import jungle.HandTris.domain.Member;
-import jungle.HandTris.domain.repo.MemberRepository;
 import jungle.HandTris.global.dto.ResponseEnvelope;
 import jungle.HandTris.global.jwt.JWTUtil;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
 import jungle.HandTris.presentation.dto.response.MemberDetailRes;
-import jungle.HandTris.presentation.dto.response.MemberIdDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.http.HttpHeaders;
@@ -23,7 +21,6 @@ public class AuthController {
 
     private final MemberService memberService;
     private final JWTUtil jwtUtil;
-    private final MemberRepository memberRepository;
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
@@ -35,17 +32,21 @@ public class AuthController {
 
     @PostMapping("/signin")
     public ResponseEntity<MemberDetailRes> signin(@RequestBody MemberRequest memberRequest) {
-        Pair<MemberDetailRes, String> result = memberService.signin(memberRequest);
+        Pair<Member, String> result = memberService.signin(memberRequest);
 
+        Member member = result.getFirst();
         String accessToken = result.getSecond();
-        String refreshToken = memberRepository.findByUsername(memberRequest.username()).getRefreshToken();
+        String refreshToken = member.getRefreshToken();
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(jwtUtil.accessHeader, accessToken);
         headers.add(jwtUtil.refreshHeader, refreshToken);
 
+        MemberDetailRes memberDetailRes = new MemberDetailRes(member);
+
+
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(result.getFirst());
+                .body(memberDetailRes);
     }
 }

--- a/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithToken.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithToken.java
@@ -1,0 +1,8 @@
+package jungle.HandTris.presentation.dto.response;
+
+public record MemberDetailResWithToken (String username,
+                                        String nickname,
+                                        String accessToken,
+                                        String refreshToken) {
+
+}


### PR DESCRIPTION
> Closes #60

## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#60 

## 반영 사항
- 로그인 시 Token도 Body에 넘겨주기 위한 Response 생성
- 로그인 시 반환 타입을 ResponseEnvelope 변경 및 header에 담았던 token을 body에 담는 MemberDetailResWithToken로 변경
- 로그인 시 불필요한 DB 접근 수정
## 유의 사항

## 관련이슈

## 참여자
- @thun0514 