### PR TITLE
로그아웃 구현

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/MemberServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberServiceImpl.java
@@ -1,11 +1,9 @@
 package jungle.HandTris.application.impl;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jungle.HandTris.application.service.MemberService;
 import jungle.HandTris.domain.Member;
-import jungle.HandTris.domain.exception.DuplicateNicknameException;
-import jungle.HandTris.domain.exception.DuplicateUsernameException;
-import jungle.HandTris.domain.exception.PasswordMismatchException;
-import jungle.HandTris.domain.exception.UserNotFoundException;
+import jungle.HandTris.domain.exception.*;
 import jungle.HandTris.domain.repo.MemberRepository;
 import jungle.HandTris.global.jwt.JWTUtil;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
@@ -66,5 +64,19 @@ public class MemberServiceImpl implements MemberService {
         Member data = new Member(username, bCryptPasswordEncoder.encode(password), nickname);
 
         memberRepository.save(data);
+    }
+
+    @Transactional
+    public void signout(HttpServletRequest request) {
+        String accessToken = jwtUtil.resolveAccessToken(request);
+
+        if (jwtUtil.isExpired(accessToken)) {
+            throw new AccessTokenExpiredException();
+        }
+
+        String nickname = jwtUtil.getNickname(accessToken);
+
+        memberRepository.findByNickname(nickname)
+                .ifPresent(Member::deleteRefreshToken);
     }
 }

--- a/src/main/java/jungle/HandTris/application/service/MemberService.java
+++ b/src/main/java/jungle/HandTris/application/service/MemberService.java
@@ -1,5 +1,6 @@
 package jungle.HandTris.application.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jungle.HandTris.domain.Member;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
 import org.springframework.data.util.Pair;
@@ -8,5 +9,7 @@ public interface MemberService {
     Pair<Member, String> signin(MemberRequest memberRequest);
 
     void signup(MemberRequest memberRequest);
+
+    void signout(HttpServletRequest request);
 
 }

--- a/src/main/java/jungle/HandTris/domain/Member.java
+++ b/src/main/java/jungle/HandTris/domain/Member.java
@@ -35,4 +35,8 @@ public class Member {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void deleteRefreshToken() {
+        this.refreshToken = null;
+    }
 }

--- a/src/main/java/jungle/HandTris/domain/exception/AccessTokenExpiredException.java
+++ b/src/main/java/jungle/HandTris/domain/exception/AccessTokenExpiredException.java
@@ -1,0 +1,4 @@
+package jungle.HandTris.domain.exception;
+
+public class AccessTokenExpiredException extends RuntimeException {
+}

--- a/src/main/java/jungle/HandTris/domain/exception/RefreshTokenExpiredException.java
+++ b/src/main/java/jungle/HandTris/domain/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,4 @@
+package jungle.HandTris.domain.exception;
+
+public class RefreshTokenExpiredException extends RuntimeException {
+}

--- a/src/main/java/jungle/HandTris/global/exception/ErrorCode.java
+++ b/src/main/java/jungle/HandTris/global/exception/ErrorCode.java
@@ -30,7 +30,9 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.", Set.of(PasswordMismatchException.class)),
 
     TOKEN_NOT_PROVIDED(HttpStatus.UNAUTHORIZED, "토큰이 제공되지 않았습니다.", Set.of(TokenNotProvideException.class)),
-    INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다.", Set.of(InvalidTokenFormatException.class));
+    INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다.", Set.of(InvalidTokenFormatException.class)),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Access 토큰이 만료되었습니다.", Set.of(AccessTokenExpiredException.class)),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다.", Set.of(RefreshTokenExpiredException.class));
 
 
     private final HttpStatusCode status;

--- a/src/main/java/jungle/HandTris/global/jwt/JWTUtil.java
+++ b/src/main/java/jungle/HandTris/global/jwt/JWTUtil.java
@@ -74,8 +74,7 @@ public class JWTUtil {
     public String createAccessToken(String nickname) {
         Date now = new Date();
 
-        return bearerPrefix + " " +
-                Jwts.builder()
+        return Jwts.builder()
                         .header()
                             .type("JWT")
                         .and()
@@ -92,8 +91,7 @@ public class JWTUtil {
     public String createRefreshToken() {
         Date now = new Date();
 
-        return bearerPrefix +" " +
-                Jwts.builder()
+        return Jwts.builder()
                         .header()
                             .type("JWT")
                         .and()

--- a/src/main/java/jungle/HandTris/presentation/AuthController.java
+++ b/src/main/java/jungle/HandTris/presentation/AuthController.java
@@ -6,7 +6,7 @@ import jungle.HandTris.application.service.MemberService;
 import jungle.HandTris.domain.Member;
 import jungle.HandTris.global.dto.ResponseEnvelope;
 import jungle.HandTris.presentation.dto.request.MemberRequest;
-import jungle.HandTris.presentation.dto.response.MemberDetailResWithToken;
+import jungle.HandTris.presentation.dto.response.MemberDetailResWithTokenRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
@@ -28,20 +28,20 @@ public class AuthController {
     }
 
     @PostMapping("/signin")
-    public ResponseEnvelope<MemberDetailResWithToken> signin(@RequestBody MemberRequest memberRequest) {
+    public ResponseEnvelope<MemberDetailResWithTokenRes> signin(@RequestBody MemberRequest memberRequest) {
         Pair<Member, String> result = memberService.signin(memberRequest);
 
         Member member = result.getFirst();
         String accessToken = result.getSecond();
 
-        MemberDetailResWithToken memberDetailResWithToken = new MemberDetailResWithToken(
+        MemberDetailResWithTokenRes memberDetailResWithTokenRes = new MemberDetailResWithTokenRes(
                 member.getUsername(),
                 member.getNickname(),
                 accessToken,
                 member.getRefreshToken()
         );
 
-        return ResponseEnvelope.of(memberDetailResWithToken);
+        return ResponseEnvelope.of(memberDetailResWithTokenRes);
     }
 
     @GetMapping("/signout")

--- a/src/main/java/jungle/HandTris/presentation/AuthController.java
+++ b/src/main/java/jungle/HandTris/presentation/AuthController.java
@@ -1,5 +1,6 @@
 package jungle.HandTris.presentation;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jungle.HandTris.application.service.MemberService;
 import jungle.HandTris.domain.Member;
@@ -41,5 +42,12 @@ public class AuthController {
         );
 
         return ResponseEnvelope.of(memberDetailResWithToken);
+    }
+
+    @GetMapping("/signout")
+    public ResponseEnvelope<String> signout(HttpServletRequest request) {
+        memberService.signout(request);
+
+        return ResponseEnvelope.of("Signout Successful");
     }
 }

--- a/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithToken.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithToken.java
@@ -1,8 +1,0 @@
-package jungle.HandTris.presentation.dto.response;
-
-public record MemberDetailResWithToken (String username,
-                                        String nickname,
-                                        String accessToken,
-                                        String refreshToken) {
-
-}

--- a/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithTokenRes.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/MemberDetailResWithTokenRes.java
@@ -1,0 +1,8 @@
+package jungle.HandTris.presentation.dto.response;
+
+public record MemberDetailResWithTokenRes(String username,
+                                          String nickname,
+                                          String accessToken,
+                                          String refreshToken) {
+
+}


### PR DESCRIPTION
> Closes #63 
## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#63 
## 반영 사항
- 클라이언트가 `signout` GET 요청을 했을 시 토큰을 받아와 검증 후 해당 유저의 DB에서 Refresh Token을 제거
## 유의 사항
- 현재 `MemberServiceImpl`에 구현된 `signout` 내에 토큰 유효기간 검증 코드인 `jwtUtil.isExpired(accessToken)`에서
JWT 기본 Exception(`ExpiredJwtException`)이 먼저 처리 되어
CustomException(`AccessTokenExpiredException`, `RefreshTokenExpiredException`)이 올바르게 나오지 않음
  - 추후 Spring Security Filter를 구현하며 CustomException이 나오도록 수정 예정
- Test Code 역시 Security Filter를 구현 후 구현 예정
## 관련이슈

## 참여자
- @thun0514 