### PR TITLE
토큰을 통해 해당 유저의 정보를 반환

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/MemberInfoServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberInfoServiceImpl.java
@@ -1,0 +1,37 @@
+package jungle.HandTris.application.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
+import jungle.HandTris.application.service.MemberInfoService;
+import jungle.HandTris.domain.Member;
+import jungle.HandTris.domain.repo.MemberRepository;
+import jungle.HandTris.domain.exception.*;
+import jungle.HandTris.global.jwt.JWTUtil;
+import jungle.HandTris.presentation.dto.response.MemberDetailRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoServiceImpl implements MemberInfoService {
+
+    private final JWTUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberDetailRes getMemberInfo(HttpServletRequest request) {
+        String accessToken = jwtUtil.resolveAccessToken(request);
+
+        if (jwtUtil.isExpired(accessToken)) {
+            throw new AccessTokenExpiredException();
+        }
+
+        String nickname = jwtUtil.getNickname(accessToken);
+
+        Member member = memberRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+
+        String username = member.getUsername();
+        return new MemberDetailRes(username, nickname);
+    }
+}

--- a/src/main/java/jungle/HandTris/application/service/MemberInfoService.java
+++ b/src/main/java/jungle/HandTris/application/service/MemberInfoService.java
@@ -1,0 +1,8 @@
+package jungle.HandTris.application.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jungle.HandTris.presentation.dto.response.MemberDetailRes;
+
+public interface MemberInfoService {
+    MemberDetailRes getMemberInfo(HttpServletRequest request);
+}

--- a/src/main/java/jungle/HandTris/presentation/TokenController.java
+++ b/src/main/java/jungle/HandTris/presentation/TokenController.java
@@ -1,0 +1,24 @@
+package jungle.HandTris.presentation;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jungle.HandTris.application.service.MemberInfoService;
+import jungle.HandTris.global.dto.ResponseEnvelope;
+import jungle.HandTris.presentation.dto.response.MemberDetailRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+public class TokenController {
+    private final MemberInfoService memberInfoService;
+
+    @GetMapping("/member/info")
+    public ResponseEnvelope<MemberDetailRes> getMemberInfoToToken(HttpServletRequest request) {
+        MemberDetailRes memberDetail = memberInfoService.getMemberInfo(request);
+
+        return ResponseEnvelope.of(memberDetail);
+    }
+}


### PR DESCRIPTION
> Closes #68 

## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#68 
## 반영 사항
- Token을 받아와 해당 유저의 정보(username, nickname)을 반환
## 유의 사항
- Token의 주인과 요청한 유저가 동일한지 검증하는 로직이 필요할 것으로 판단
  - Spring Security의 `@PreAuthorize` 어노테이션을 사용하여 권한 검사를 구현할 수 있을 것으로 예상.
## 관련이슈

## 참여자
- @thun0514 