### PR TITLE
닉네임을 통해 해당 유저의 정보를 조회하는 기능

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/MemberProfileServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberProfileServiceImpl.java
@@ -35,6 +35,17 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     private String defaultImage;
 
     @Override
+    public Pair<String, MemberRecordDetailRes> getMemberProfileWithStatsByNickname(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+
+        String profileImageUrl = member.getProfileImageUrl();
+        MemberRecordDetailRes memberRecordDetails = new MemberRecordDetailRes(memberRecordService.getMemberRecord(nickname));
+
+        return Pair.of(profileImageUrl, memberRecordDetails);
+    }
+
+    @Override
     public MemberDetailRes loadMemberProfileByToken(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization").substring(7);
 

--- a/src/main/java/jungle/HandTris/application/service/MemberProfileService.java
+++ b/src/main/java/jungle/HandTris/application/service/MemberProfileService.java
@@ -10,6 +10,8 @@ import org.springframework.data.util.Pair;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberProfileService {
+    Pair<String, MemberRecordDetailRes> getMemberProfileWithStatsByNickname(String nickname);
+
     MemberDetailRes loadMemberProfileByToken(HttpServletRequest request);
 
     Pair<MemberProfileDetailsRes, MemberRecordDetailRes> myPage(HttpServletRequest request, String username);


### PR DESCRIPTION
> Closes #85 

## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#85 
## 반영 사항
- `Nickname`을 통해 해당 유저의 `ProfileImageUrl`과 `GameRecord`를 반환하는 메소드 생성
## 유의 사항

## 관련이슈

## 참여자
- @thun0514 