### PR TITLE
TetrisController 및 StompHandler 수정

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/GameRoomServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/GameRoomServiceImpl.java
@@ -12,7 +12,6 @@ import jungle.HandTris.domain.exception.GameRoomNotFoundException;
 import jungle.HandTris.domain.exception.MemberNotFoundException;
 import jungle.HandTris.domain.exception.ParticipantLimitedException;
 import jungle.HandTris.domain.exception.PlayingGameException;
-import jungle.HandTris.domain.repo.GameMemberRepository;
 import jungle.HandTris.domain.repo.GameRoomRepository;
 import jungle.HandTris.global.validation.UserNicknameFromJwt;
 import jungle.HandTris.presentation.dto.request.GameMemberEssentialDTO;
@@ -34,7 +33,6 @@ public class GameRoomServiceImpl implements GameRoomService {
     private final GameRoomRepository gameRoomRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final MemberProfileService memberProfileService;
-    private final GameMemberRepository gameMemberRepository;
 
     private static final String GAME_MEMBER_KEY_PREFIX = "gameMember:";
 
@@ -55,7 +53,7 @@ public class GameRoomServiceImpl implements GameRoomService {
 
     @Override
     public UUID createGameRoom(@UserNicknameFromJwt String nickname, GameRoomDetailReq gameRoomDetailReq) {
-        GameRoom createdGameRoom = new GameRoom(nickname,gameRoomDetailReq.title());
+        GameRoom createdGameRoom = new GameRoom(nickname, gameRoomDetailReq.title());
         gameRoomRepository.save(createdGameRoom);
         // nickname으로 프로필 Url과 전적 추출
         Pair<String, MemberRecordDetailRes> memberDetails = memberProfileService.getMemberProfileWithStatsByNickname(nickname);

--- a/src/main/java/jungle/HandTris/application/impl/TetrisServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/TetrisServiceImpl.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TetrisServiceImpl implements TetrisService {
 
-//    private final GameRoomService gameRoomService;
-
     private final GameMemberRepository gameMemberRepository;
 
     public RoomOwnerRes checkRoomOwnerAndReady(String roomCode) {
@@ -23,5 +21,4 @@ public class TetrisServiceImpl implements TetrisService {
         }
         return new RoomOwnerRes(false);
     }
-
 }

--- a/src/main/java/jungle/HandTris/domain/exception/DestinationUrlNotFoundException.java
+++ b/src/main/java/jungle/HandTris/domain/exception/DestinationUrlNotFoundException.java
@@ -1,0 +1,4 @@
+package jungle.HandTris.domain.exception;
+
+public class DestinationUrlNotFoundException extends RuntimeException {
+}

--- a/src/main/java/jungle/HandTris/global/exception/ErrorCode.java
+++ b/src/main/java/jungle/HandTris/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     GAME_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "게임이 존재하지 않습니다.", Set.of(GameRoomNotFoundException.class)),
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "유저가 존재하지 않습니다.", Set.of(MemberNotFoundException.class)),
     MEMBER_RECORD_NOT_FOUND(HttpStatus.BAD_REQUEST, "전적이 존재하지 않습니다.", Set.of(MemberRecordNotFoundException.class)),
+    DESTINATION_URL_NOT_FOUND(HttpStatus.BAD_REQUEST, "목적지 주소가 존재하지 않습니다.", Set.of(DestinationUrlNotFoundException.class)),
 
     NICKNAME_NOT_CHANGED(HttpStatus.BAD_REQUEST, "현재 닉네임과 동일한 닉네임입니다.", Set.of(NicknameNotChangedException.class)),
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 타입입니다.", Set.of(InvalidImageTypeException.class)),
@@ -38,7 +39,7 @@ public enum ErrorCode {
     INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "잘못된 토큰 형식입니다.", Set.of(InvalidTokenFormatException.class)),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Access 토큰이 만료되었습니다.", Set.of(AccessTokenExpiredException.class)),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다.", Set.of(RefreshTokenExpiredException.class)),
-  
+
     DISCORD_LOG_APPENDER(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 로그 전송에 실패하였습니다", Set.of(DiscordLogException.class)),
     DISCORD_CONNECT(HttpStatus.INTERNAL_SERVER_ERROR, "디스코드 연결에 실패하였습니다", Set.of(DiscordException.class));
 

--- a/src/main/java/jungle/HandTris/presentation/TetrisController.java
+++ b/src/main/java/jungle/HandTris/presentation/TetrisController.java
@@ -1,6 +1,5 @@
 package jungle.HandTris.presentation;
 
-import jungle.HandTris.application.service.GameRoomService;
 import jungle.HandTris.application.service.TetrisService;
 import jungle.HandTris.presentation.dto.request.RoomStateReq;
 import jungle.HandTris.presentation.dto.request.TetrisMessageReq;
@@ -8,37 +7,27 @@ import jungle.HandTris.presentation.dto.response.RoomOwnerRes;
 import jungle.HandTris.presentation.dto.response.RoomStateRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestController;
-
 
 @RestController
 @RequiredArgsConstructor
 public class TetrisController {
     private final SimpMessagingTemplate messagingTemplate;
-    private final GameRoomService gameRoomService;
     private final TetrisService tetrisService;
 
     @MessageMapping("/{roomCode}/tetris")
-    public void handleTetrisMessage(@DestinationVariable String roomCode, TetrisMessageReq message) {
-//        GameMember gameMember = gameRoomService.getGameMember(roomCode); // GameRoomService에서 특정 방 가져오기
-
-//        if (gameMember != null) {
-//            Set<String> connectedUsers = gameMember.getMembers().stream()
-//                    .filter(memberId -> !memberId.equals(message.sender())) // 메시지 보낸 사람 제외
-//                    .collect(Collectors.toSet());
-//
-//            connectedUsers.forEach(memberId ->
-//                    messagingTemplate.convertAndSendToUser(memberId, "queue/tetris", message)
-//            );
-//        }
+    public void handleTetrisMessage(@DestinationVariable String roomCode, TetrisMessageReq message, @Header("otherUser") String otherUser) {
+        // Sender가 아닌 유저에게 메시지 전달
+        messagingTemplate.convertAndSendToUser(otherUser, "queue/tetris", message);
     }
 
     @MessageMapping("/{roomCode}/owner/info")
     public void roomOwnerInfo(@DestinationVariable String roomCode) {
         RoomOwnerRes roomOwnerRes = tetrisService.checkRoomOwnerAndReady(roomCode);
-        messagingTemplate.convertAndSend("/topic/owner/" + roomCode, roomOwnerRes); //TOPIC은 Prefix이기 때문에 roomCode가 뒤에 가도록 변경해주세요
+        messagingTemplate.convertAndSend("/topic/owner/" + roomCode, roomOwnerRes);
     }
 
     @MessageMapping("/{roomCode}/tetris/ready")

--- a/src/main/java/jungle/HandTris/presentation/dto/request/TetrisMessageReq.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/request/TetrisMessageReq.java
@@ -1,4 +1,4 @@
 package jungle.HandTris.presentation.dto.request;
 
-public record TetrisMessageReq(String sender, String[][] board, boolean isEnd) {
+public record TetrisMessageReq(String[][] board, boolean isEnd, boolean isAttack) {
 }


### PR DESCRIPTION
> Closes #94

## PR 타입 (하나 이상의 PR 타입 선택)
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#94 
## 반영 사항
- TetrisController 및 StompHandler 수정
    - StompHandler에서 sender가 아닌 유저 찾기
    - 찾은 유저를 header에 담아 controller로 전달
    - DestinationUrlNotFoundException 예외처리 추가
    - handleTetrisMessage 수정
        - 받은 유저에게만 메시지 전송
- STOMP 메시지 수정 (공격 관련 로직)
    - TetrisMessageReq
        - isAttack 필드 추가 (boolean)
## 유의 사항

## 관련이슈

## 참여자
- @otfeb 