### PR TITLE
GameRoom 도메인의 GameStatus 필드 삭제

### DIFF
--- a/src/main/java/jungle/HandTris/application/service/GameRoomService.java
+++ b/src/main/java/jungle/HandTris/application/service/GameRoomService.java
@@ -1,6 +1,5 @@
 package jungle.HandTris.application.service;
 
-import jungle.HandTris.domain.GameMember;
 import jungle.HandTris.domain.GameRoom;
 import jungle.HandTris.global.validation.UserNicknameFromJwt;
 import jungle.HandTris.presentation.dto.request.GameRoomDetailReq;
@@ -11,13 +10,10 @@ import java.util.UUID;
 public interface GameRoomService {
     List<GameRoom> getGameRoomList();
 
-    GameMember getGameRoom(String roomCode);
-
     UUID createGameRoom(@UserNicknameFromJwt String nickname, GameRoomDetailReq gameRoomDetailReq);
 
     GameRoom enterGameRoom(@UserNicknameFromJwt String nickname, String roomCode);
 
     GameRoom exitGameRoom(@UserNicknameFromJwt String nickname, String roomCode);
 
-    boolean isGameRoomPlaying(String roomCode);
 }

--- a/src/main/java/jungle/HandTris/domain/GameRoom.java
+++ b/src/main/java/jungle/HandTris/domain/GameRoom.java
@@ -28,17 +28,12 @@ public class GameRoom {
     @Column(nullable = false)
     private UUID roomCode;
 
-    @Column(nullable = false)
-    @Enumerated(value = EnumType.STRING)
-    private GameStatus gameStatus;
-
     public GameRoom(String creator, String title) {
         this.title = title;
         this.creator = creator;
         this.participantCount = 1;
         this.participantLimit = 2;
         this.roomCode = UUID.randomUUID();
-        this.gameStatus = GameStatus.NON_PLAYING;
     }
 
     public void enter() {

--- a/src/main/java/jungle/HandTris/domain/repo/GameRoomRepository.java
+++ b/src/main/java/jungle/HandTris/domain/repo/GameRoomRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface GameRoomRepository extends Repository<GameRoom, Long> {
 
-    @Query("SELECT g FROM GameRoom g WHERE g.participantCount < g.participantLimit AND g.gameStatus != 'PLAYING' ")
+    @Query("SELECT g FROM GameRoom g WHERE g.participantCount < g.participantLimit")
     List<GameRoom> findAllByGameStatusNotPlaying();
 
     Optional<GameRoom> findById(Long id);

--- a/src/main/java/jungle/HandTris/presentation/dto/response/GameRoomDetailRes.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/GameRoomDetailRes.java
@@ -5,7 +5,6 @@ import jungle.HandTris.domain.GameRoom;
 import java.util.UUID;
 
 public record GameRoomDetailRes(
-        long id,
         String title,
         String creator,
         long participantCount,
@@ -13,7 +12,7 @@ public record GameRoomDetailRes(
         UUID roomCode
 ) {
     public GameRoomDetailRes(GameRoom gameRoom) {
-        this(gameRoom.getId(),
+        this(
                 gameRoom.getTitle(),
                 gameRoom.getCreator(),
                 gameRoom.getParticipantCount(),

--- a/src/main/java/jungle/HandTris/presentation/dto/response/GameRoomDetailRes.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/GameRoomDetailRes.java
@@ -1,7 +1,6 @@
 package jungle.HandTris.presentation.dto.response;
 
 import jungle.HandTris.domain.GameRoom;
-import jungle.HandTris.domain.GameStatus;
 
 import java.util.UUID;
 
@@ -11,8 +10,7 @@ public record GameRoomDetailRes(
         String creator,
         long participantCount,
         long participantLimit,
-        UUID roomCode,
-        GameStatus gameStatus
+        UUID roomCode
 ) {
     public GameRoomDetailRes(GameRoom gameRoom) {
         this(gameRoom.getId(),
@@ -20,7 +18,6 @@ public record GameRoomDetailRes(
                 gameRoom.getCreator(),
                 gameRoom.getParticipantCount(),
                 gameRoom.getParticipantLimit(),
-                gameRoom.getRoomCode(),
-                gameRoom.getGameStatus());
+                gameRoom.getRoomCode());
     }
 }

--- a/src/main/resources/db/migration/V3__delete_game_status.sql
+++ b/src/main/resources/db/migration/V3__delete_game_status.sql
@@ -1,0 +1,2 @@
+ALTER table game_room
+    DROP COLUMN game_status;


### PR DESCRIPTION
> Closes #122 

## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#122 

## 반영 사항
- GameRoom 도메인의 gameStatus 필드 삭제
- 연계되는 isGameRoomPlaying메소드, 조건문 삭제

## 유의 사항
추가 삭제 
- 사용하지 않는 getGameRoom 메소드 삭제
- 반환 DTO인 GameRoomDetailRes에서 Entity의 PK를 제거

## 관련이슈

## 참여자
- @forrest1398 