### PR TITLE
 게임방에 참여한 인원들의 정보를 조회하는 api 구현

### DIFF
--- a/src/main/java/jungle/HandTris/application/impl/MemberRecordServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberRecordServiceImpl.java
@@ -1,19 +1,27 @@
 package jungle.HandTris.application.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import jungle.HandTris.application.service.MemberRecordService;
+import jungle.HandTris.domain.GameMember;
 import jungle.HandTris.domain.Member;
 import jungle.HandTris.domain.MemberRecord;
 import jungle.HandTris.domain.exception.MemberNotFoundException;
 import jungle.HandTris.domain.exception.MemberRecordNotFoundException;
 import jungle.HandTris.domain.repo.MemberRecordRepository;
 import jungle.HandTris.domain.repo.MemberRepository;
+import jungle.HandTris.presentation.dto.request.GameMemberEssentialDTO;
 import jungle.HandTris.presentation.dto.request.GameResult;
 import jungle.HandTris.presentation.dto.request.GameResultReq;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -22,6 +30,8 @@ public class MemberRecordServiceImpl implements MemberRecordService {
 
     private final MemberRecordRepository memberRecordRepository;
     private final MemberRepository memberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String GAME_MEMBER_KEY_PREFIX = "gameMember:";
 
     @Override
     public MemberRecord getMemberRecord(String nickname) {
@@ -52,4 +62,71 @@ public class MemberRecordServiceImpl implements MemberRecordService {
         }
         return memberRecord;
     }
+
+    @Override
+    public List<MemberRecord> getParticipants(String roomCode, String nickname) {
+
+        List<MemberRecord> result = new ArrayList<>();
+        String gameKey = GAME_MEMBER_KEY_PREFIX + roomCode;
+
+        // 본인 전적
+        Optional<Member> member = memberRepository.findByNickname(nickname);
+        System.out.println(member.get().getNickname() + "--------------------------------------------");
+        if (member.isEmpty()) {
+            throw new MemberNotFoundException();
+        }
+        Optional<MemberRecord> MyRecord = memberRecordRepository.findByMember(member.get());
+        if (MyRecord.isEmpty()) {
+            throw new MemberRecordNotFoundException();
+        }
+        result.add(MyRecord.get());
+
+        // 상대 전적
+        GameMember gameMember = getGameMemberFromCache(roomCode);
+        Set<GameMemberEssentialDTO> cachedUsers = gameMember.getMembers();
+        Optional<GameMemberEssentialDTO> otherUser = findOtherUser(cachedUsers, nickname);
+
+        // 상대가 없을 경우
+        if (otherUser.isEmpty()) {
+            result.add(null);
+        }
+        // 상대가 있을 경우
+        else {
+            Optional<Member> otherMember = memberRepository.findByNickname(otherUser.get().nickname());
+            System.out.println(otherMember.get().getNickname() + "--------------------------------------------");
+            if (otherMember.isEmpty()) {
+                throw new MemberNotFoundException();
+            }
+            Optional<MemberRecord> otherRecord = memberRecordRepository.findByMember(otherMember.get());
+            if (otherRecord.isEmpty()) {
+                throw new MemberRecordNotFoundException();
+            }
+            result.add(otherRecord.get());
+        }
+        return result;
+    }
+
+    private Optional<GameMemberEssentialDTO> findOtherUser(Set<GameMemberEssentialDTO> cachedUser, String nickname) {
+        return cachedUser.stream()
+                .filter(dto -> !dto.nickname().equals(nickname))
+                .findFirst();
+    }
+
+    private GameMember getGameMemberFromCache(String roomCode) {
+        String gameMemberGen = redisTemplate.opsForValue().get(GAME_MEMBER_KEY_PREFIX + roomCode);
+        return generateGameMember(gameMemberGen);
+    }
+
+    private GameMember generateGameMember(String gameMemberGen) {
+        try {
+            if (gameMemberGen != null) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.readValue(gameMemberGen, GameMember.class);
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        throw new MemberNotFoundException();
+    }
+
 }

--- a/src/main/java/jungle/HandTris/application/impl/MemberRecordServiceImpl.java
+++ b/src/main/java/jungle/HandTris/application/impl/MemberRecordServiceImpl.java
@@ -71,7 +71,6 @@ public class MemberRecordServiceImpl implements MemberRecordService {
 
         // 본인 전적
         Optional<Member> member = memberRepository.findByNickname(nickname);
-        System.out.println(member.get().getNickname() + "--------------------------------------------");
         if (member.isEmpty()) {
             throw new MemberNotFoundException();
         }
@@ -93,7 +92,6 @@ public class MemberRecordServiceImpl implements MemberRecordService {
         // 상대가 있을 경우
         else {
             Optional<Member> otherMember = memberRepository.findByNickname(otherUser.get().nickname());
-            System.out.println(otherMember.get().getNickname() + "--------------------------------------------");
             if (otherMember.isEmpty()) {
                 throw new MemberNotFoundException();
             }

--- a/src/main/java/jungle/HandTris/application/service/MemberRecordService.java
+++ b/src/main/java/jungle/HandTris/application/service/MemberRecordService.java
@@ -3,8 +3,12 @@ package jungle.HandTris.application.service;
 import jungle.HandTris.domain.MemberRecord;
 import jungle.HandTris.presentation.dto.request.GameResultReq;
 
+import java.util.List;
+
 public interface MemberRecordService {
     MemberRecord getMemberRecord(String nickname);
 
     MemberRecord updateMemberRecord(GameResultReq gameResultReq, String nickname);
+
+    List<MemberRecord> getParticipants(String roomCode, String nickname);
 }

--- a/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
+++ b/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
@@ -50,10 +50,9 @@ public class MemberRecordController {
     }
 
     @GetMapping
-    public ResponseEnvelope<MemberRecordDetailRes> getMyRecord(@UserNicknameFromJwt String nickname) {
+    public ResponseEnvelope<ParticipantRes> getMyRecord(@UserNicknameFromJwt String nickname) {
         MemberRecord memberRecord = memberRecordService.getMemberRecord(nickname);
-        MemberRecordDetailRes memberRecordDetailRes = new MemberRecordDetailRes(memberRecord);
-        return ResponseEnvelope.of(memberRecordDetailRes);
+        ParticipantRes participantRes = new ParticipantRes(memberRecord);
+        return ResponseEnvelope.of(participantRes);
     }
-
 }

--- a/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
+++ b/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
@@ -49,5 +49,11 @@ public class MemberRecordController {
         return ResponseEnvelope.of(participantResList);
     }
 
+    @GetMapping
+    public ResponseEnvelope<MemberRecordDetailRes> getMyRecord(@UserNicknameFromJwt String nickname) {
+        MemberRecord memberRecord = memberRecordService.getMemberRecord(nickname);
+        MemberRecordDetailRes memberRecordDetailRes = new MemberRecordDetailRes(memberRecord);
+        return ResponseEnvelope.of(memberRecordDetailRes);
+    }
 
 }

--- a/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
+++ b/src/main/java/jungle/HandTris/presentation/MemberRecordController.java
@@ -7,8 +7,12 @@ import jungle.HandTris.global.dto.ResponseEnvelope;
 import jungle.HandTris.global.validation.UserNicknameFromJwt;
 import jungle.HandTris.presentation.dto.request.GameResultReq;
 import jungle.HandTris.presentation.dto.response.MemberRecordDetailRes;
+import jungle.HandTris.presentation.dto.response.ParticipantRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @RestController
@@ -31,5 +35,19 @@ public class MemberRecordController {
         MemberRecordDetailRes memberRecordDetailRes = new MemberRecordDetailRes(memberRecord);
         return ResponseEnvelope.of(memberRecordDetailRes);
     }
+
+    @GetMapping("/participant/{roomCode}")
+    public ResponseEnvelope<List<ParticipantRes>> getParticipants(@PathVariable("roomCode") String roomCode, @UserNicknameFromJwt String nickname) {
+        List<MemberRecord> participantsMemberRecord = memberRecordService.getParticipants(roomCode, nickname);
+        List<ParticipantRes> participantResList = new ArrayList<>();
+        for (MemberRecord memberRecord : participantsMemberRecord) {
+            if (memberRecord == null)
+                continue;
+            ParticipantRes participantRes = new ParticipantRes(memberRecord);
+            participantResList.add(participantRes);
+        }
+        return ResponseEnvelope.of(participantResList);
+    }
+
 
 }

--- a/src/main/java/jungle/HandTris/presentation/dto/response/ParticipantRes.java
+++ b/src/main/java/jungle/HandTris/presentation/dto/response/ParticipantRes.java
@@ -1,0 +1,24 @@
+package jungle.HandTris.presentation.dto.response;
+
+import jungle.HandTris.domain.MemberRecord;
+
+import java.math.BigDecimal;
+
+public record ParticipantRes(
+        String nickname,
+        String profileImageUrl,
+        long win,
+        long lose,
+        BigDecimal winRate
+) {
+    public ParticipantRes(MemberRecord memberRecord) {
+        this(
+                memberRecord.getMember().getNickname(),
+                memberRecord.getMember().getProfileImageUrl(),
+                memberRecord.getWin(),
+                memberRecord.getLose(),
+                memberRecord.getRate()
+        );
+    }
+
+}


### PR DESCRIPTION
> Closes #126 

## PR 타입 (하나 이상의 PR 타입 선택)
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 설정 변경 (Config Class)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
#126
## 반영 사항
roomCode와 JWT를 이용해, 해당 방에 참여한 인원들의 정보 조회
1. 닉네임
2. 프로필 이미지 url
3. 승리한 게임 수
4. 패배한 게임 수
5. 승률

## 유의 사항
추가 구현 api
- 토큰을 생성한 사용자의 정보 조회 api(임시)


## 관련이슈
#126

## 참여자
- @forrest1398 